### PR TITLE
add table for number of delivered orders [delivers #161787462]

### DIFF
--- a/UI/userprofile.html
+++ b/UI/userprofile.html
@@ -84,6 +84,12 @@
               <td>Mbarara</td>
             </tr>
           </table>
+          <table class="table2">
+            <tr>
+              <th>Total Delivered</th>
+              <td>3</td>
+            </tr>
+          </table>
     </div>
   </body>
 </html>


### PR DESCRIPTION
__What does this PR do:__
 Adds a table for a normal user to be able to view the number of parcel delivery orders that have been delivered.

_Acceptance Criteria_
GIVEN A normal user 
WHEN User navigates to the user home page
THEN User should be able to view the number of parcel delivery orders that have been delivered.

**DEV NOTES**
User should be able to see a table showing the total number of parcel delivery orders that have been delivered.

**DESIGN Notes**
Simple and attractive table in the home page