### PR TITLE
161787943 orders in transit

### DIFF
--- a/UI/userprofile.html
+++ b/UI/userprofile.html
@@ -89,6 +89,10 @@
               <th>Total Delivered</th>
               <td>3</td>
             </tr>
+            <tr>
+              <th>Total In-transit</th>
+              <td>2</td>
+            </tr>
           </table>
     </div>
   </body>


### PR DESCRIPTION
__What does this PR do:__
Adds a table for a normal user to be able to view the number of parcel delivery orders that are yet to be delivered(in-transit).

_Acceptance Criteria_
GIVEN A normal user 
WHEN User navigates to the user home page
THEN User should be able to view the number of parcel delivery orders that are yet to be delivered.

**DEV NOTES**
User should be able to see a table showing the total number of parcel delivery orders that are yet to be delivered.

**DESIGN Notes**
Simple and attractive table in the home page