### PR TITLE
add adminprofile with table of clients [delivers #161859322]

### DIFF
--- a/UI/adminprofile.html
+++ b/UI/adminprofile.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="author" content="Michael Robert Wali">
+    <title>sendit</title>
+    <link href="css/style.css" type="text/css" rel="stylesheet">
+    <script type="text/javascript" src="scripts/main.js"></script>
+  </head>
+  <body class="innerbody">
+    <nav>
+        <a href="index.html">Logout</a>
+        <a href="adminprofile.html">Profile</a>
+        <a href="adminhome.html">Home</a>
+    </nav>
+    <div class="profile">
+      <div class="profile-pic">
+        <img src="images/profilepic.png">
+      </div>
+      <table>
+        <tr>
+          <th>Name:</th>
+          <td>Michael Wali</td>
+        </tr>
+        <tr>
+          <th>Sex:</th>
+          <td>Male</td>
+        </tr>
+        <tr>
+          <th>User ID:</th>
+          <td>45</td>
+        </tr>
+        <tr>
+          <th>Account-type:</th>
+          <td>Admin User</td>
+        </tr>
+      </table>
+    </div>
+    <div class="parcel-orders">
+        <h1>All Parcels</h1>
+        <div class="table">
+          <table>
+            <tr>
+              <th>Parcel Name</th>
+              <th>Client Name</th>
+              <th>Cost</th>
+              <th>Status</th>
+              <th>From</th>
+              <th>Destination</th>
+            </tr>
+            <tr>
+              <td>Gas cooker</td>
+              <td>Derrick Lubega</td>
+              <td>shs. 550,000</td>
+              <td>In transit</td>
+              <td>Kalangala</td>
+              <td>Mbarara</td>
+            </tr>
+            <tr>
+              <td>Radio</td>
+              <td>Sempal Ivan</td>
+              <td>shs. 50,000</td>
+              <td>Delivered</td>
+              <td>Luwero</td>
+              <td>Mityana</td>
+            </tr>
+            <tr>
+              <td>Building material</td>
+              <td>Machese Dan</td>
+              <td>shs. 1,250,000</td>
+              <td>In transit</td>
+              <td>Kampala</td>
+              <td>Arua</td>
+            </tr>
+            <tr>
+              <td>Calculator</td>
+              <td>Isaac Muhangi</td>
+              <td>shs. 50,000</td>
+              <td>Delivered</td>
+              <td>Kampala</td>
+              <td>Mbarara</td>
+            </tr>
+            <tr>
+              <td>Boda boda</td>
+              <td>Derrick Nagenda</td>
+              <td>shs. 2,550,000</td>
+              <td>In transit</td>
+              <td>Kampala</td>
+              <td>Masindi</td>
+            </tr>
+          </table>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
__What does this PR do:__
Adds an admin profile page for admin user to be able to view a profile with different client names and  parcel delivery order.

_Acceptance Criteria_
GIVEN An admin user 
WHEN User navigates to the admin profile page
THEN User should be able to view various client names with their parcel delivery orders.

**DEV NOTES**
User should be able to see a page with profile info and client orders.

**DESIGN Notes**
Simple and attractive profile page