### PR TITLE
Ft change destination 162076240

### DIFF
--- a/api/models/parcels.py
+++ b/api/models/parcels.py
@@ -34,3 +34,10 @@ class ParcelDb(Dbcontroller):
         self.cursor.execute(query,)
         parcel = self.cursor.fetchone()
         return parcel
+
+    def update_parcel_destination(self,destination, parcel_id):
+        query = "UPDATE parcels SET parcel_destination = '{}' WHERE parcelid  = '{}'".format(destination, parcel_id)
+        #query = "UPDATE parcels SET %s = %s WHERE parcelid = %s"
+        self.cursor.execute(query,)
+        parcel = self.cursor.fetchone()
+        return parcel

--- a/api/views/parcels.py
+++ b/api/views/parcels.py
@@ -44,7 +44,7 @@ def fetch_parcel_by_specific_user():
     user_id = get_jwt_identity()['user_id']
     return jsonify({"Parcel":parcel_db.fetch_parcel_by_specific_user(user_id)})
 
-@appblueprint.route('/parcels/<int:parcel_id>/status', methods=['POST'])
+@appblueprint.route('/parcels/<int:parcel_id>/status', methods=['PUT'])
 @jwt_required
 def change_order_status(parcel_id):
     user_role = get_jwt_identity()['role']
@@ -54,4 +54,15 @@ def change_order_status(parcel_id):
     if not parcel_db.fetch_parcel(parcel_id):
         return jsonify({"message":"order does not exist"})
     parcel_db.update_parcel(new_status,parcel_id)
-    return(jsonify({"message":"successfully updated"})),200
+    return jsonify({"message":"successfully updated"}),200
+
+@appblueprint.route('/parcels/<int:parcel_id>/destination', methods=['PUT'])
+@jwt_required
+def change_order_destination(parcel_id):
+    destination = request.json['Destination']
+    user_id = get_jwt_identity()['user_id']
+    parcel = parcel_db.fetch_specific_order(parcel_id)
+    if parcel['usrid'] != user_id:
+        return jsonify({"message":"you are not the owner of this parcel"}),400
+    parcel_db.update_parcel_destination(destination,parcel_id)
+    return jsonify({"message":"destination successfully changed"}),200    


### PR DESCRIPTION
_What does this PR do:_ 
Addsendpoint for a registered User to be able to change the destination of a specific parcel delivery order

_Acceptance Criteria_
GIVEN A registered user 
WHEN User navigates to t`v2/api/parcels/parcelid/destination`
THEN User should be able to submit json data in the form {"Destination":"New destination"} to change the order destination.

**DEV NOTES**
Create end point for putting data. Add validations for user input and functionality.
This endpoint is accessible only by the owner of the parcels only.
