### PR TITLE
Ft change present location admin 162076305

### DIFF
--- a/api/models/parcels.py
+++ b/api/models/parcels.py
@@ -37,7 +37,12 @@ class ParcelDb(Dbcontroller):
 
     def update_parcel_destination(self,destination, parcel_id):
         query = "UPDATE parcels SET parcel_destination = '{}' WHERE parcelid  = '{}'".format(destination, parcel_id)
-        #query = "UPDATE parcels SET %s = %s WHERE parcelid = %s"
+        self.cursor.execute(query,)
+        parcel = self.cursor.fetchone()
+        return parcel
+
+    def change_location(self,location,parcel_id):
+        query = "UPDATE parcels SET present_location = '{}' WHERE parcelid  = '{}'".format(present_location, parcel_id)
         self.cursor.execute(query,)
         parcel = self.cursor.fetchone()
         return parcel

--- a/api/views/parcels.py
+++ b/api/views/parcels.py
@@ -69,3 +69,13 @@ def change_order_destination(parcel_id):
         return jsonify({"message":"you are not the owner of this parcel"}),400
     parcel_db.update_parcel_destination(destination,parcel_id)
     return jsonify({"message":"destination successfully changed"}),200
+
+@appblueprint.route(' /parcels/<int:parcel_id>/presentLocation', methods=['PUT'])
+@jwt_required
+def change_order_present_location(parcel_id):
+    location = request.json['Present Location']
+    role = get_jwt_identity()['role']
+    if user_role.lower() != 'admin':
+        return jsonify({"message":"Unauthorized access"}),401
+    parcel_db.change_location(location,parcel_id)
+    return jsonify({"message":"present location successfully changed"}),200


### PR DESCRIPTION
_What does this PR do:_ 
Adds endpoint for a registered admin user to be able to change the present location of a specific parcel delivery order

_Acceptance Criteria_
GIVEN A registered user 
WHEN User navigates to t` /parcels/<parcelId>/presentLocation`
THEN User should be able to submit json data in the form {"Present Location":"New Location"} to change the order location.

**DEV NOTES**
Create end point for putting data. Add validations for user input and functionality.
This endpoint is accessible only by the owner of the parcels only.
